### PR TITLE
Vagrant / Ansible 2 become_user issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Kafka
 
-Master: [![Build Status](https://travis-ci.org/ansible-city/kafka.svg?branch=master)](https://travis-ci.org/ansible-city/kafka)  
-Develop: [![Build Status](https://travis-ci.org/ansible-city/kafka.svg?branch=develop)](https://travis-ci.org/ansible-city/kafka)
+Master: [![Build Status](https://travis-ci.org/jpbarto/kafka.svg?branch=master)](https://travis-ci.org/jpbarto/kafka)  
+Develop: [![Build Status](https://travis-ci.org/jpbarto/kafka.svg?branch=develop)](https://travis-ci.org/jpbarto/kafka)
 
 * [ansible.cfg](#ansible-cfg)
 * [Installation and Dependencies](#installation-and-dependencies)

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ To install run `ansible-galaxy install ansible-city.kafka` or add this to your
 `roles.yml`
 
 ```YAML
-- name: ansible-city.kafka
-  version: v1.0
+- name: jpbarto.kafka
+  version: v1.0.4
 ```
 
 and run `ansible-galaxy install -p ./roles -r roles.yml`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,7 @@ kafka:
   upstart_conf: /etc/init/kafka.conf
   use_systemd: no
   user: kafka
+  group: kafka
   version_kafka: "0.9.0.0"
   version_scala: "2.11"
   zookeeper_connection_timeout_ms: 1000000

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -7,10 +7,11 @@
 
 - name: Ensure install folders
   become: yes
-  become_user: "{{ kafka.user }}"
   file:
     state: directory
     path: "{{ item }}"
+    owner: "{{ kafka.user }}"
+    group: "{{ kafka.group }}"
   with_items:
     - "/home/{{ kafka.user }}/tmp"
     - "/home/{{ kafka.user }}/log"
@@ -24,33 +25,35 @@
 
 - name: Fetch kafka binary package
   become: yes
-  become_user: "{{ kafka.user }}"
   get_url:
     dest: "/home/{{ kafka.user }}/tmp/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}.tgz"
     url: "{{ kafka.apache_mirror }}/kafka/{{ kafka.version_kafka }}/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}.tgz"
 
 - name: Uncompress the kafka tar
   become: yes
-  become_user: "{{ kafka.user }}"
   unarchive:
     copy: no
     creates: "/home/{{ kafka.user }}/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}"
     dest: "/home/{{ kafka.user }}"
     src: "/home/{{ kafka.user }}/tmp/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}.tgz"
+    owner: "{{ kafka.user }}"
+    group: "{{ kafka.group }}"
 
 - name: Link kafka to the right version
   become: yes
-  become_user: "{{ kafka.user }}"
   file:
     path: "/home/{{ kafka.user }}/kafka"
     src: "/home/{{ kafka.user }}/kafka_{{ kafka.version_scala }}-{{ kafka.version_kafka }}"
     state: link
+    owner: "{{ kafka.user }}"
+    group: "{{ kafka.group }}"
 
 - name: link config dir
   become: yes
-  become_user: "{{ kafka.user }}"
   file:
     force: yes
     path: "/home/{{ kafka.user }}/etc"
     src: "/home/{{ kafka.user }}/kafka/config"
     state: link
+    owner: "{{ kafka.user }}"
+    group: "{{ kafka.group }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -50,21 +50,23 @@
 
 - name: Create log4j.properties
   become: yes
-  become_user: "{{ kafka.user }}"
   template:
     dest: "/home/{{ kafka.user }}/etc/log4j.properties"
     mode: 0644
     src: log4j.properties.j2
+    owner: "{{ kafka.user }}"
+    group: "{{ kafka.user }}"
   notify:
     - restart kafka
 
 - name: Create server.properties
   become: yes
-  become_user: "{{ kafka.user }}"
   template:
     dest: "/home/{{ kafka.user }}/etc/server.properties"
     mode: 0640
     src: server.properties.j2
+    owner: "{{ kafka.user }}"
+    group: "{{ kafka.user }}"
   notify:
     - restart kafka
 


### PR DESCRIPTION
Using the Kafka playbook from Vagrant with Ansible 2.0.0.2 was resulting in errors.

Example:
`fatal: [kafka1]: FAILED! => {"changed": true, "failed": true, "module_stderr": "", "module_stdout": "Sorry, user vagrant is not allowed to execute '/bin/sh -c echo BECOME-SUCCESS-yxkniqdvfruyabkozrvbofhtxvsvdnxq; LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /tmp/ansible-tmp-1458043580.46-43435778950785/copy' as kafka on kafka1.mefisto.local.\r\n", "msg": "MODULE FAILURE", "parsed": false}`

By swapping `become_user` for `owner` and `group` parameters seems to sort it.
